### PR TITLE
+ke

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Your favorite package is not listed? Fork and [create a Pull Request](https://gi
 - [ods](https://github.com/owainlewis/ods) – A large collection of data structures and algorithms for OCaml.
 - [combine](https://github.com/backtracking/combine) – OCaml library for combinatorics <https://www.lri.fr/~filliatr/combine/>.
 - [Decompress](https://github.com/mirage/decompress) - A pure OCaml implementation of Zlib
+- [Ke](https://github.com/mirage/ke) - Fast implementation of queue (FIFO) in OCaml
 
 ## Application Libraries
 


### PR DESCRIPTION
[Ke] is a little library which implements in some ways a FIFO. From benchmarks, one implementation of them is fast (more than `Stdlib.Queue` or `Base.Queue`). At this stage, from tests and a fuzzer, we check a lot this implementation which now is stable - so we are able to promote it 👍 .