### PR TITLE
+duff

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Your favorite package is not listed? Fork and [create a Pull Request](https://gi
 - [ods](https://github.com/owainlewis/ods) – A large collection of data structures and algorithms for OCaml.
 - [combine](https://github.com/backtracking/combine) – OCaml library for combinatorics <https://www.lri.fr/~filliatr/combine/>.
 - [Decompress](https://github.com/mirage/decompress) - A pure OCaml implementation of Zlib
+= [Duff](https://github.com/mirage/duff) - Implementation of Rabin's fingerprint and delta compression by P. MacDonald in OCaml (same as [libXdiff](http://www.xmailserver.org/xdiff-lib.html)
 
 ## Application Libraries
 


### PR DESCRIPTION
Duff is a good little library used by `ocaml-git` which implements Rabin's fingerprint and delta compression by P. MacDonald in OCaml. Used currently in `ocaml-git`, we fuzz it and test it in a real world context.