### PR TITLE
Add Caramel to Languages and Compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Your favorite package is not listed? Fork and [create a Pull Request](https://gi
 ## Compilers and Compiler Tools
 
 - **Languages and Compilers**:
-  - [caramel](https://caramel.run/) - caramel is a functional language for building type-safe, scalable, and maintainable applications
+  - [Caramel](https://caramel.run/) - Caramel is a functional language for building type-safe, scalable, and maintainable applications.
   - [cDuce](http://www.cduce.org/) - cDuce is a modern XML-oriented functional language with innovative features.
   - [Compcert C Compiler](http://compcert.inria.fr/) - It is a C Compiler supporting most of the ISO C90 and C99 / ANSI C  features.
   - [Eff Programming Language](http://www.eff-lang.org/) - Eff is a functional language with handlers of not only exceptions, but also of other computational effects such as state or I/O.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Your favorite package is not listed? Fork and [create a Pull Request](https://gi
 ## Compilers and Compiler Tools
 
 - **Languages and Compilers**:
+  - [caramel](https://caramel.run/) - caramel is a functional language for building type-safe, scalable, and maintainable applications
   - [cDuce](http://www.cduce.org/) - cDuce is a modern XML-oriented functional language with innovative features.
   - [Compcert C Compiler](http://compcert.inria.fr/) - It is a C Compiler supporting most of the ISO C90 and C99 / ANSI C  features.
   - [Eff Programming Language](http://www.eff-lang.org/) - Eff is a functional language with handlers of not only exceptions, but also of other computational effects such as state or I/O.


### PR DESCRIPTION
Caramel is currently compiling a subset of OCaml syntax to Erlang source code