### PR TITLE
Add a link to lthms’s blogposts about OCaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your favorite package is not listed? Fork and [create a Pull Request](https://gi
 - [Type OCaml – Many things about OCaml](http://typeocaml.com/)
 - [OCaml Platform](https://opam.ocaml.org/blog/)
 - [Drup's Thingies](https://drup.github.io/)
+- [Thomas Letan’s articles about OCaml](https://soap.coffee/~lthms/tags/ocaml.html)
 
 ## Books
 


### PR DESCRIPTION
Hi!

I sometimes write stuff™ on my blog and sometimes it is about OCaml. I wouldn’t call these articles rocket science but still, they might be interested for the typical audience of this awesome list.

No hard feelings if you’d rather not add it! I would totally understand.